### PR TITLE
Refactor/api versioning and npm scripts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export const config = {
   deployEnvironment: process.env.DEPLOY_ENV || 'dev',
   forceEnableORMRepositories: process.env.ENABLE_TEST_ORM_REPOSITORIES === 'true',
   listeningPort: parseInt(process.env.APP_PORT || '8080', 10),
+  apiVersioningPrefix: process.env.API_VERSIONING_PREFIX || 'api/v',
   neutrinoApi: {
     baseURL: process.env.NEUTRINO_API_BASE_URL || 'https://neutrinoapi.net',
     userId: process.env.NEUTRINO_API_USER_ID || 'borjatango',

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ async function bootstrap() {
 
   app.enableVersioning({
     type: VersioningType.URI,
+    prefix: config.apiVersioningPrefix,
   })
 
   // Add Morgan for HTTP Logging

--- a/test/utils/TestClient.ts
+++ b/test/utils/TestClient.ts
@@ -48,6 +48,7 @@ export class TestClient {
     const nestApplication: INestApplication = moduleFixture.createNestApplication()
     nestApplication.enableVersioning({
       type: VersioningType.URI,
+      prefix: config.apiVersioningPrefix,
     })
     await nestApplication.init()
 
@@ -61,7 +62,7 @@ export class TestClient {
   }
 
   createUser({ name = MICHAEL.name, lastName = MICHAEL.lastName, phone = MICHAEL.phone } = {}) {
-    return tepper(this.app).post('/v1/users').send({
+    return tepper(this.app).post('/api/v1/users').send({
       name,
       lastName,
       phone,
@@ -69,15 +70,15 @@ export class TestClient {
   }
 
   updateUserContacts({ id = '', contacts = MICHAEL.contacts } = {}) {
-    return tepper(this.app).post(`/v1/users/${id}/contacts`).send(contacts)
+    return tepper(this.app).post(`/api/v1/users/${id}/contacts`).send(contacts)
   }
 
   getUserContacts({ id = '' }) {
-    return tepper(this.app).get(`/v1/users/${id}/contacts`)
+    return tepper(this.app).get(`/api/v1/users/${id}/contacts`)
   }
 
   getCommonContacts(userId1: string, userId2: string) {
-    return tepper(this.app).get(`/v1/users/common-contacts`).withQuery({
+    return tepper(this.app).get(`/api/v1/users/common-contacts`).withQuery({
       userId1,
       userId2,
     })


### PR DESCRIPTION
This PR updates the Nest.js API versioning while implementing a URI schema like `/api/vX/abcd` for versioning, as required by @mercuriete for infra deployments. This value can even be changed from environment.

Also, adds changes to npm scripts:
- Adds a npm `precommit` script to optionally run and ensure all files are correctly formatted before commit.
- Also pairs `format` scripts with `lint`and `test` ones, having labels for `check`, `fix` and `ci` 

CC: @acidjuan @DanielRamosAcosta 