### PR TITLE
fix(dockerignore): nest-cli.json was being ignored while building doc…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !src
 !yarn.lock
 !package.json
+!nest-cli.json
 !tsconfig.json
 !tsconfig.build.json
 !docker/entrypoint.local.sh


### PR DESCRIPTION
…ker image

* Even though it seems harmless, some projects do really need that configuration and behaves very badly.